### PR TITLE
Allow multiple arguments in Decorator render method

### DIFF
--- a/src/Decorator.php
+++ b/src/Decorator.php
@@ -40,7 +40,11 @@ class Decorator
             throw new BadMethodCallException("Method [$name] does not exist.");
         }
 
-        return call_user_func($this->macros[$name], $data);
+        $args = func_get_args();
+
+        array_shift($args);
+
+        return call_user_func_array($this->macros[$name], $args);
     }
 
     /**


### PR DESCRIPTION
Using the decorator macro, if I want to pass in multiple arguments to be passed to the view, I need to pass an array. However retrieving all method arguments would allow awesome type hinted macros that support more than one parameter. For example:

``` php
Decorator::macro('issue-comment', function (Comment $comment, Issue $issue)  {
    return view('components.issue-comment', compact('comment', 'issue'));
});
```

Usage:

``` php
@decorator('issue-comment', $comment, $issue);
```

I left the method signature the same (the `$data` param) for backwards compatibility.
